### PR TITLE
Update apiGet to use tanstack

### DIFF
--- a/app/api/api.tsx
+++ b/app/api/api.tsx
@@ -1,11 +1,18 @@
-export async function apiGet<T>(url: string): Promise<T> {
-    const response = await fetch(url);
+import { useQuery } from "@tanstack/react-query";
 
-    if (response.ok) {
-        return response.json() as Promise<T>;
+export function apiGet<T>(
+    key: string,
+    url: string
+    ): UseQueryResult<T> {
+        return useQuery<T>({
+            queryKey: [key],
+            queryFn: async () => {
+                const response = await fetch(url);
+                if (!response.ok) {
+                    const text = await response.text();
+                    throw new Error(`API Error: ${response.status} - ${text}`)
+                }
+                return response.json() as Promise<T>;
+            }
+        });
     }
-
-    const text = await response.text;
-    const status = response.status;
-    throw new Error(`API Error: ${status} - ${text}`);
-}

--- a/app/api/restaurant_service.tsx
+++ b/app/api/restaurant_service.tsx
@@ -1,13 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
 import { rootQueryUrl, allRestaurantsEndpoint } from "~/root";
+import { apiGet } from "~/api/api";
 import type { Restaurant } from "~/interfaces";
 
 export let useGetAllRestaurants = () =>
-  useQuery<Restaurant[]>({
-    queryKey: ["restaurants"],
-    queryFn: async () => {
-      const res = await fetch(`${rootQueryUrl}/${allRestaurantsEndpoint}`);
-      if (!res.ok) throw new Error("Failed to fetch restaurants");
-      return res.json();
-    },
-  });
+    apiGet<Restaurant[]>("restaurants", `${rootQueryUrl}/${allRestaurantsEndpoint}`);

--- a/app/api/vending_machine_service.tsx
+++ b/app/api/vending_machine_service.tsx
@@ -1,13 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
 import { rootQueryUrl, allVendingMachinesEndpoint } from "~/root";
+import { apiGet } from "~/api/api";
 import type { VendingMachine } from "~/interfaces";
 
 export let useGetAllVendingMachines = () =>
-  useQuery<VendingMachine[]>({
-    queryKey: ["vending_machines"],
-    queryFn: async () => {
-      const res = await fetch(`${rootQueryUrl}/${allVendingMachinesEndpoint}`);
-      if (!res.ok) throw new Error("Failed to fetch vending machines");
-      return res.json();
-    },
-  });
+    apiGet<VendingMachine[]>("vending_machines", `${rootQueryUrl}/${allVendingMachinesEndpoint}`);


### PR DESCRIPTION
## 📄 Pull Request Description

---

### 🧩 What was changed?

Rewrote apiGet function that is used to reach to backend API, to use tanstack just as implemented useGetAllRestaurtants and useGetAllVendingMachines, which now properly use this interface.

---

### 💡 Why was it changed?

To standardize API calls across the application, obey the DRY (Do not Repeat Yourself) principle and to ensure consistency in error handling and fetching behaviour.

---

### ⚙️ How was it implemented?

- Created a generic apiGet<T> function that wraps useQuery from tanstack.
- Updated existing hooks (useGetAllRestaurants, useGetAllVendingMachines) to use apiGet for API calls.
- No new technologies were introduced.

---

### ⚠️ Side Effects or Risks
Hooks now rely entirely on apiGet, so any bug in this function could affect multiple parts of the application.
Changes to query keys or fetch behavior might impact caching and refetch behavior.
No additional requests are introduced beyond what the original hooks already did.

---

## ✅ Checklist

- [X] All 4 sections above are clearly filled out
- [X] Tests and documentation updated 

