### PR TITLE
feat: Synchronize overview with Figma via darkmode

### DIFF
--- a/app/components/login/login_component.tsx
+++ b/app/components/login/login_component.tsx
@@ -10,7 +10,7 @@ export default function LoginComponent() {
                 <div className="h-1/10"></div>
                 <LoginCard></LoginCard>
             </div>
-            <BottomNav></BottomNav>
+            <BottomNav page={"login"}></BottomNav>
         </>
     )
 }

--- a/app/components/map/map_component.tsx
+++ b/app/components/map/map_component.tsx
@@ -8,7 +8,7 @@ export function MapComponent() {
         <TopBar isLoginPage={false}></TopBar>
       <div className="flex-1">
         <Map_proper />
-        <BottomNav />
+        <BottomNav page={"map"}></BottomNav>
       </div>
     </div>
   );

--- a/app/components/overview/filter_bar.tsx
+++ b/app/components/overview/filter_bar.tsx
@@ -29,6 +29,7 @@ export function FilterBar({ value, onChange }: FilterBarProps) {
       <ToggleGroup
           type="multiple"
           variant="outline"
+          className={"pt-5"}
           spacing={0}
           size="sm"
           value={value}
@@ -36,7 +37,7 @@ export function FilterBar({ value, onChange }: FilterBarProps) {
           <ToggleGroupItem
               value="vegan"
               aria-label="Toggle vegan"
-              className="flex-1 data-[state=on]:bg-transparent data-[state=on]:*:[svg]:stroke-blue-500"
+              className="flex-1 data-[state=on]:bg-transparent data-[state=on]:*:[svg]:stroke-martynablue"
           >
               <Vegan />
               <div className={"hidden osm1:block"}>
@@ -46,7 +47,7 @@ export function FilterBar({ value, onChange }: FilterBarProps) {
           <ToggleGroupItem
               value="vegetarian"
               aria-label="Toggle vegetarian"
-              className="flex-1 data-[state=on]:bg-transparent  data-[state=on]:*:[svg]:stroke-blue-500"
+              className="flex-1 data-[state=on]:bg-transparent  data-[state=on]:*:[svg]:stroke-martynablue"
           >
               <Sprout />
               <div className={"hidden osm1:block"}>
@@ -56,7 +57,7 @@ export function FilterBar({ value, onChange }: FilterBarProps) {
           <ToggleGroupItem
               value="lactoseFree"
               aria-label="Toggle lactose free"
-              className="flex-1 data-[state=on]:bg-transparent  data-[state=on]:*:[svg]:stroke-blue-500"
+              className="flex-1 data-[state=on]:bg-transparent  data-[state=on]:*:[svg]:stroke-martynablue"
           >
               <MilkOff />
               <div className={"hidden osm1:block"}>
@@ -66,7 +67,7 @@ export function FilterBar({ value, onChange }: FilterBarProps) {
           <ToggleGroupItem
               value="glutenFree"
               aria-label="Toggle gluten free"
-              className="flex-1 osm1:justify-center data-[state=on]:bg-transparent  data-[state=on]:*:[svg]:stroke-blue-500"
+              className="flex-1 osm1:justify-center data-[state=on]:bg-transparent  data-[state=on]:*:[svg]:stroke-martynablue"
           >
               <WheatOff />
               <div className={"hidden osm1:block"}>

--- a/app/components/overview/overview_component.tsx
+++ b/app/components/overview/overview_component.tsx
@@ -18,27 +18,33 @@ export function OverviewComponent() {
     const [filters, setFilters] = React.useState<FilterValue[]>([])
 
     return (
-        <>
+        <div className={"dark:bg-zinc-950"}>
             <TopBar isLoginPage={false} />
-            <div className="w-full" style={{ height: "calc(100vh - 150px)" }}>
-                <SearchBar />
+            <div className={"pt-5 pl-5 pr-5 dark:bg-zinc-950"}>
+                <div className="w-full" style={{ height: "calc(100vh - 200px)" }}>
+                    <SearchBar></SearchBar>
 
-                <FilterBar value={filters} onChange={setFilters} />
+                        <FilterBar value={filters} onChange={setFilters} />
 
-                <ServiceSectionStripe stripeTitle={"Restaurants"} />
-                <ServiceSection
-                    carouselItemSource={useGetAllRestaurants}
-                    variant="restaurant"
-                    filters={filters}
-                />
+                    <div className={"pt-5"}>
+                        <ServiceSectionStripe stripeTitle={"Restaurants"} />
+                        <ServiceSection
+                            carouselItemSource={useGetAllRestaurants}
+                            variant="restaurant"
+                            filters={filters}
+                        />
+                    </div>
 
-                <ServiceSectionStripe stripeTitle={"Vending Machines"} />
-                <ServiceSection
-                    carouselItemSource={useGetAllVendingMachines}
-                    variant="vending"
-                />
+                    <div className={"pt-5"}>
+                        <ServiceSectionStripe stripeTitle={"Vending Machines"} />
+                        <ServiceSection
+                            carouselItemSource={useGetAllVendingMachines}
+                            variant="vending"
+                        />
+                    </div>
+                </div>
+            <BottomNav page={"overview"}></BottomNav>
             </div>
-            <BottomNav />
-        </>
+        </div>
     )
 }

--- a/app/components/overview/service_section/restaurant_tile.tsx
+++ b/app/components/overview/service_section/restaurant_tile.tsx
@@ -9,19 +9,19 @@ interface RestaurantTileProps {
 
 export function RestaurantTile({ name, description, openNow, onClick }: RestaurantTileProps) {
     return (
-        <div onClick={onClick} className="w-[227px] h-[148px] rounded-2xl overflow-hidden flex flex-col bg-black cursor-pointer">
+        <div onClick={onClick} className="w-[227px] h-[148px] rounded-xl overflow-hidden flex flex-col bg-black cursor-pointer">
 
             <div className="flex-1 bg-white" />
 
             <div className="bg-[#1B1B1B] px-3 py-2">
 
                 <div className="flex items-center justify-between">
-                    <h3 className="text-[8.5px] font-semibold leading-tight truncate text-white">
+                    <h3 className="text-[10.5px] font-semibold leading-tight truncate text-white">
                         {name}
                     </h3>
 
                     <span
-                        className={`text-[8.5px] font-semibold ${
+                        className={`text-[10.5px] font-semibold ${
                             openNow ? "text-[#2ECC71]" : "text-[#E74C3C]"
                         }`}
                     >
@@ -29,7 +29,7 @@ export function RestaurantTile({ name, description, openNow, onClick }: Restaura
           </span>
                 </div>
 
-                <p className="text-[6.3px] leading-snug line-clamp-2 text-white opacity-90 mt-1">
+                <p className="text-[8.3px] leading-snug line-clamp-2 text-white opacity-90 mt-1">
                     {description}
                 </p>
             </div>

--- a/app/components/overview/service_section/section_carousel.tsx
+++ b/app/components/overview/service_section/section_carousel.tsx
@@ -30,12 +30,12 @@ export function SectionCarousel({ items, variant }: SectionCarouselProps) {
     const [selectedPoint, setSelectedPoint] = useState<Facility | null>(null);
 
     return (
-        <div className="flex justify-center px-14">
-            <Carousel className="w-full max-w-[227px]" opts={{ align: "start", loop: true }}>
+        <div className="flex justify-center">
+            <Carousel className="w-full" opts={{ align: "start", loop: true }}>
                 <CarouselContent>
                     {items.map((item, index) => (
-                        <CarouselItem key={item.id ?? index}>
-                            <div className="p-1 flex justify-center">
+                        <CarouselItem key={item.id ?? index} className={"basis-1/2 sm:basis-1/3"}>
+                            <div className="py-1 flex justify-center">
                                 {variant === "restaurant" ? (
                                     <RestaurantTile
                                         name={item.name}
@@ -54,8 +54,8 @@ export function SectionCarousel({ items, variant }: SectionCarouselProps) {
                     ))}
                 </CarouselContent>
 
-                <CarouselPrevious />
-                <CarouselNext />
+                {/*<CarouselPrevious />*/}
+                {/*<CarouselNext />*/}
             </Carousel>
             {selectedPoint && (
                 <FacilityInfo

--- a/app/components/overview/service_section/vending_machine_tile.tsx
+++ b/app/components/overview/service_section/vending_machine_tile.tsx
@@ -6,12 +6,12 @@ interface VendingMachineTileProps {
 
 export function VendingMachineTile({ description }: VendingMachineTileProps) {
     return (
-        <div className="w-[227px] h-[148px] rounded-2xl overflow-hidden flex flex-col bg-black">
+        <div className="w-[227px] h-[148px] rounded-xl overflow-hidden flex flex-col bg-black">
 
             <div className="flex-1 bg-white" />
 
             <div className="bg-[#1B1B1B] px-3 py-2">
-                <h3 className="text-[8.5px] font-semibold leading-snug text-white line-clamp-2">
+                <h3 className="text-[10.5px] font-semibold leading-snug text-white line-clamp-2">
                     {description}
                 </h3>
             </div>

--- a/app/components/overview/service_section_stripe.tsx
+++ b/app/components/overview/service_section_stripe.tsx
@@ -14,14 +14,15 @@ import {
 export function ServiceSectionStripe({stripeTitle} : {stripeTitle: string}) {
   return (
     <div className="flex w-full max-w-full flex-col gap-2">
-      <Item variant="outline" size="xsm">
-        <ItemContent>
+      <Item variant="outline" border="none" size="xsm" rounded="rounded">
+        <ItemContent className={"dark:text-martynablue"}>
           <ItemTitle>{stripeTitle}</ItemTitle>
         </ItemContent>
         <ItemActions>
-          <Button variant="outline" size="xsm">
-            See All
-          </Button>
+          {/* deprecated */}
+          {/*<Button variant="outline" size="xsm">*/}
+          {/*  See All*/}
+          {/*</Button>*/}
         </ItemActions>
       </Item>
     </div>

--- a/app/components/shared/bottom_nav.tsx
+++ b/app/components/shared/bottom_nav.tsx
@@ -2,24 +2,27 @@ import { ItemActions } from "~/shadcn/components/ui/item"
 import { Button } from "~/shadcn/components/ui/button"
 import { Home, Map, User } from "lucide-react"
 
-export function BottomNav() {
+export function BottomNav({page}: {page : string}) {
     return (
         <div className="flex w-full justify-center">
-            <nav className="flex items-center gap-8 py-3">
+            <nav className="flex items-center gap-8 p-3 mb-10 rounded-xl dark:bg-zinc-900">
                 <Button
-                    variant="ghost"
+                    variant={page === "overview" ? "highlight" : "ghost"}
+                    border="none"
                     onClick={() => (window.location.href = "/")}
                     >
                     <Home className=""/>
                 </Button>
                 <Button
-                    variant="ghost"
+                    variant={page === "map" ? "highlight" : "ghost"}
+                    border="none"
                     onClick={() => (window.location.href = "/map")}
                     >
                     <Map className=""/>
                 </Button>
                 <Button
-                    variant="ghost"
+                    variant={page === "profile" || page === "login" ? "highlight" : "ghost"}
+                    border="none"
                     onClick={() => (window.location.href = "/login")}
                     >
                     <User className=""/>

--- a/app/components/shared/top_bar.tsx
+++ b/app/components/shared/top_bar.tsx
@@ -15,19 +15,23 @@ export function TopBar({isLoginPage}: {isLoginPage: boolean}) {
   var itemClassName: string = isLoginPage ? "justify-center" : "justify-between"
     return (
     <div className="flex w-full flex-row">
-      <Item variant="outline" size="xsm" width="default" className={itemClassName}>
-          <div className="flex items-center gap-1.5">
-              <ItemMedia variant="logo" onClick={() => (window.location.href = "/")}>
+      <Item variant="outline" size="xsm" width="default" className={`itemClassName`}>
+          <div></div>
+          <div className="flex items-center">
+              <ItemMedia variant="logo" className={"scale-120 dark:invert"} onClick={() => (window.location.href = "/")}>
                   <img src="/logo.svg"></img>
               </ItemMedia>
               <ItemContent className={"hidden 3xs:block"}>
-                  <ItemTitle>JU Can Eat</ItemTitle>
+                  <div></div>
+                  <ItemTitle className={"text-base pt-2"}>JU Can Eat</ItemTitle>
+                  <div></div>
               </ItemContent>
           </div>
           <ItemActions>
               {!isLoginPage && (
                   <Button
-                      variant="outline"
+                      variant="highlight"
+                      border="none"
                       size="sm"
                       onClick={() => (window.location.href = "/login")}
                   >

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -55,7 +55,7 @@ const queryClient = new QueryClient();
 
 export default function App() {
   return <QueryClientProvider client={queryClient}>
-    <Outlet />;
+    <Outlet />
   </QueryClientProvider>
 }
 

--- a/app/shadcn/components/ui/button.tsx
+++ b/app/shadcn/components/ui/button.tsx
@@ -9,15 +9,17 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-gray-900 text-gray-50 hover:bg-gray-900/90 dark:bg-gray-50 dark:text-gray-900 dark:hover:bg-gray-50/90",
+        default: "bg-zinc-900 text-gray-50 hover:bg-zinc-900/90 dark:bg-zinc-50 dark:text-gray-900 dark:hover:bg-zinc-50/90",
         destructive:
           "bg-red-500 text-white hover:bg-red-500/90 focus-visible:ring-red-500/20 dark:focus-visible:ring-red-500/40 dark:bg-red-500/60 dark:bg-red-900 dark:hover:bg-red-900/90 dark:focus-visible:ring-red-900/20 dark:dark:focus-visible:ring-red-900/40 dark:dark:bg-red-900/60",
         outline:
-          "border bg-white shadow-xs hover:bg-gray-100 hover:text-gray-900 dark:bg-gray-200/30 dark:border-gray-200 dark:hover:bg-gray-200/50 dark:bg-gray-950 dark:hover:bg-gray-800 dark:hover:text-gray-50 dark:dark:bg-gray-800/30 dark:dark:border-gray-800 dark:dark:hover:bg-gray-800/50",
+          "bg-white shadow-xs hover:bg-zinc-100 hover:text-gray-900 dark:bg-zinc-200/30 dark:hover:bg-zinc-200/50 dark:bg-zinc-950 dark:hover:bg-zinc-800 dark:hover:text-gray-50 dark:dark:bg-zinc-800/30 dark:dark:hover:bg-zinc-800/50",
+        highlight:
+          "bg-white shadow-xs hover:bg-zinc-100 hover:text-gray-900 dark:bg-zinc-200/30 dark:text-martynablue dark:hover:bg-zinc-200/50 dark:bg-zinc-950 dark:hover:bg-zinc-800 dark:hover:text-gray-50 dark:dark:bg-zinc-800/30 dark:dark:hover:bg-zinc-800/50",
         secondary:
-          "bg-gray-100 text-gray-900 hover:bg-gray-100/80 dark:bg-gray-800 dark:text-gray-50 dark:hover:bg-gray-800/80",
+          "bg-zinc-100 text-gray-900 hover:bg-zinc-100/80 dark:bg-zinc-800 dark:text-gray-50 dark:hover:bg-zinc-800/80",
         ghost:
-          "hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-100/50 dark:hover:bg-gray-800 dark:hover:text-gray-50 dark:dark:hover:bg-gray-800/50",
+          "dark:text-zinc-50 hover:bg-zinc-100 hover:text-gray-900 dark:hover:bg-zinc-100/50 dark:hover:bg-zinc-800 dark:hover:text-gray-50 dark:dark:hover:bg-zinc-800/50",
         link: "text-gray-900 underline-offset-4 hover:underline dark:text-gray-50",
       },
       size: {
@@ -29,10 +31,20 @@ const buttonVariants = cva(
         "icon-sm": "size-8",
         "icon-lg": "size-10",
       },
+      border: {
+          outline: "border dark:border-gray-200 dark:dark:border-gray-800",
+          none: "border-none"
+      },
+      rounded: {
+          default: "rounded-0",
+          rounded: "rounded-md"
+      }
     },
     defaultVariants: {
       variant: "default",
       size: "default",
+      border: "outline",
+      rounded: "default"
     },
   }
 )
@@ -40,7 +52,9 @@ const buttonVariants = cva(
 function Button({
   className,
   variant,
+  border,
   size,
+  rounded,
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> &
@@ -52,7 +66,7 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(buttonVariants({ variant, border, size, className }))}
       {...props}
     />
   )

--- a/app/shadcn/components/ui/input.tsx
+++ b/app/shadcn/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-gray-950 placeholder:text-gray-500 selection:bg-gray-900 selection:text-gray-50 dark:bg-gray-200/30 border-gray-200 h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:file:text-gray-50 dark:placeholder:text-gray-400 dark:selection:bg-gray-50 dark:selection:text-gray-900 dark:dark:bg-gray-800/30 dark:border-gray-800",
+        "file:text-gray-950 placeholder:text-gray-500 selection:bg-gray-900 selection:text-gray-50 dark:bg-zinc-800 dark:text-gray-50 border-gray-200 h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:file:text-gray-50 dark:placeholder:text-gray-50 dark:selection:bg-gray-50 dark:selection:text-gray-950 dark:border-0",
         "focus-visible:border-gray-950 focus-visible:ring-gray-950/50 dark:focus-visible:border-gray-300 dark:focus-visible:ring-gray-300/50",
         "aria-invalid:ring-red-500/20 dark:aria-invalid:ring-red-500/40 aria-invalid:border-red-500 dark:aria-invalid:ring-red-900/20 dark:dark:aria-invalid:ring-red-900/40 dark:aria-invalid:border-red-900",
         className

--- a/app/shadcn/components/ui/item.tsx
+++ b/app/shadcn/components/ui/item.tsx
@@ -31,12 +31,12 @@ function ItemSeparator({
 }
 
 const itemVariants = cva(
-  "group/item flex items-center border border-gray-200 border-transparent text-sm rounded-md transition-colors [a]:hover:bg-gray-100/50 [a]:transition-colors duration-100 flex-wrap outline-none focus-visible:border-gray-950 focus-visible:ring-gray-950/50 focus-visible:ring-[3px] dark:border-gray-800 dark:[a]:hover:bg-gray-800/50 dark:focus-visible:border-gray-300 dark:focus-visible:ring-gray-300/50",
+  "group/item flex items-center border border-gray-200 border-transparent text-sm transition-colors [a]:hover:bg-gray-100/50 [a]:transition-colors duration-100 flex-wrap outline-none focus-visible:border-gray-950 focus-visible:ring-gray-950/50 focus-visible:ring-[3px] dark:border-gray-800 dark:[a]:hover:bg-gray-800/50 dark:focus-visible:border-gray-300 dark:focus-visible:ring-gray-300/50",
   {
     variants: {
       variant: {
         default: "bg-transparent",
-        outline: "border-gray-200 dark:border-gray-800",
+        outline: "dark:bg-zinc-950 dark:text-zinc-50",
         muted: "bg-gray-100/50 dark:bg-gray-800/50",
       },
       size: {
@@ -49,13 +49,23 @@ const itemVariants = cva(
       },
       justify: {
           default: "justify-between"
-      }
+      },
+      rounded: {
+          default: "rounded-0",
+          rounded: "rounded-md"
+      },
+        border: {
+            outline: "border dark:border-gray-200 dark:dark:border-gray-800",
+            none: "border-none"
+        },
     },
     defaultVariants: {
       variant: "default",
       size: "default",
         justify: "default",
-        width: "default"
+        width: "default",
+        rounded: "default",
+        border: "outline"
     },
   }
 )
@@ -65,6 +75,8 @@ function Item({
   variant = "default",
   size = "default",
   width = "default",
+    rounded = "default",
+    border = "outline",
   asChild = false,
   ...props
 }: React.ComponentProps<"div"> &
@@ -75,7 +87,7 @@ function Item({
       data-slot="item"
       data-variant={variant}
       data-size={size}
-      className={cn(itemVariants({ variant, size, className }))}
+      className={cn(itemVariants({ variant, size, width, rounded, border, className }))}
       {...props}
     />
   )

--- a/app/shadcn/components/ui/toggle-group.tsx
+++ b/app/shadcn/components/ui/toggle-group.tsx
@@ -36,7 +36,7 @@ function ToggleGroup({
       data-spacing={spacing}
       style={{ "--gap": spacing } as React.CSSProperties}
       className={cn(
-        "group/toggle-group flex w-full items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        "group/toggle-group flex w-full items-center gap-[--spacing(var(--gap))] rounded-0 data-[spacing=default]:data-[variant=outline]:shadow-xs",
         className
       )}
       {...props}
@@ -53,6 +53,7 @@ function ToggleGroupItem({
   children,
   variant,
   size,
+  rounded,
   ...props
 }: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
   VariantProps<typeof toggleVariants>) {
@@ -68,6 +69,7 @@ function ToggleGroupItem({
         toggleVariants({
           variant: context.variant || variant,
           size: context.size || size,
+          rounded: "default"
         }),
         "w-auto min-w-0 shrink-0 focus:z-10 focus-visible:z-10",
         "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",

--- a/app/shadcn/components/ui/toggle.tsx
+++ b/app/shadcn/components/ui/toggle.tsx
@@ -5,13 +5,13 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "~/shadcn/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-xs font-medium hover:bg-gray-100 hover:text-gray-500 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-gray-100 data-[state=on]:text-gray-900 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-gray-950 focus-visible:ring-gray-950/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-red-500/20 dark:aria-invalid:ring-red-500/40 aria-invalid:border-red-500 whitespace-nowrap dark:hover:bg-gray-800 dark:hover:text-gray-400 dark:data-[state=on]:bg-gray-800 dark:data-[state=on]:text-gray-50 dark:focus-visible:border-gray-300 dark:focus-visible:ring-gray-300/50 dark:aria-invalid:ring-red-900/20 dark:dark:aria-invalid:ring-red-900/40 dark:aria-invalid:border-red-900",
+  "inline-flex items-center justify-center gap-2 text-xs font-medium dark:text-zinc-50 hover:bg-gray-100 hover:text-gray-500 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-gray-100 data-[state=on]:text-gray-900 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-gray-950 focus-visible:ring-gray-950/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-red-500/20 dark:aria-invalid:ring-red-500/40 aria-invalid:border-red-500 whitespace-nowrap dark:hover:bg-gray-800 dark:hover:text-gray-400 dark:data-[state=on]:bg-gray-800 dark:data-[state=on]:text-gray-50 dark:focus-visible:border-gray-300 dark:focus-visible:ring-gray-300/50 dark:aria-invalid:ring-red-900/20 dark:dark:aria-invalid:ring-red-900/40 dark:aria-invalid:border-red-900",
   {
     variants: {
       variant: {
         default: "bg-transparent",
         outline:
-          "border border-gray-200 bg-transparent shadow-xs hover:bg-gray-100 hover:text-gray-900 dark:border-gray-800 dark:hover:bg-gray-800 dark:hover:text-gray-50",
+          "border-3 border-gray-200 bg-transparent shadow-xs hover:bg-gray-100 hover:text-gray-900 dark:border-zinc-800 dark:hover:bg-gray-800 dark:hover:text-gray-50",
       },
       size: {
         default: "h-9 px-2 min-w-9",
@@ -19,10 +19,15 @@ const toggleVariants = cva(
           filter_bar: "h-8 px-1.5 min-w-8",
         lg: "h-10 px-2.5 min-w-10",
       },
+      rounded: {
+        default: "rounded-0",
+        rounded: "rounded-md"
+      }
     },
     defaultVariants: {
       variant: "default",
       size: "default",
+      rounded: "default"
     },
   }
 )

--- a/app/tailwind_styles.css
+++ b/app/tailwind_styles.css
@@ -6,4 +6,6 @@
     --breakpoint-2xs: 18rem; /* 288px */
     --breakpoint-xs: 20rem;  /* 320px */
     --breakpoint-osm1: 28rem; /* 448px - "our small, 1" */
+    --color-martynablue: #009de0;
+    --color-brightmartynablue: #28b9f7;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2016,6 +2017,7 @@
       "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.9.5.tgz",
       "integrity": "sha512-sww8oDNqz8SgaXEQ3maqTuMlibCMpmWvLE0s5zyEyOQb1G99clYMcXceQ2HNU2jtXJkp+P5XI1CngpGpngyTnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0",
         "@react-router/express": "7.9.5",
@@ -2675,6 +2677,7 @@
       "integrity": "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2685,6 +2688,7 @@
       "integrity": "sha512-k5dJVszUiNr1DSe8Cs+knKR6IrqhqdhpUwzqhkS8ecQTSf3THNtbfIp/umqHMpX2bv+9dkx3fwDv/86LcSfvSg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2695,6 +2699,7 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2727,6 +2732,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3130,6 +3136,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3665,7 +3672,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -3984,6 +3992,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4215,6 +4224,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6436,6 +6446,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6473,6 +6484,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6625,6 +6637,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6634,6 +6647,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6672,6 +6686,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.5.tgz",
       "integrity": "sha512-JmxqrnBZ6E9hWmf02jzNn9Jm3UqyeimyiwzD69NjxGySG6lIz/1LVPsoTCwN7NBX2XjCEa1LIX5EMz1j2b6u6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -7567,7 +7582,8 @@
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -7759,6 +7775,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7903,6 +7920,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
## 📄 Pull Request Description

Please fill out **each section** below.  
The goal is that reviewers can **understand everything without reading the code**.

---

### 🧩 What was changed?

<!-- 
Clearly describe WHAT the change is.
What feature, fix, or refactor does this PR include?
What files or areas of the app are affected?
-->

This PR implements/completes Project board task #161.
It does so by setting up the Figma-aligned version of the frontend when the browser is in dark mode. What was previously an ugly byproduct of having dark mode on is now a close representation of our Figma prototype, one that respects the old, light theme version, too.
A bunch of new divs have been added that allow centering/adjusting CSS values in a way that couldn't be done before. 

---

### 💡 Why was it changed?

<!-- 
Explain WHY this change was needed.
What problem or requirement does it address?
Why now?
-->

To decrease the distance between planned implementation and actual implementation, inching us closer to the product we agreed upon.

---

### ⚙️ How was it implemented?

<!-- 
Describe HOW the change was made.
What was the approach or solution?
Were there any alternative options considered?
Were any new technologies were used?
-->

TailwindCSS & cva manipulations, as well as new state passed to the `<BottomNav>` component to track which part should be highlighted in cyan.

---

### ⚠️ Side Effects or Risks

<!-- 
Are there any side effects?
Could this break anything?
Could this impact the work of another team member?
Mention things like performance impact, backward compatibility, security concerns, etc.
-->

Yes - a lower margin has been added to BottomNav, because I'm still bad at CSS and couldn't figure out how to move it upwards otherwise. This may or may not be troublesome with the Map component. It renders at a different height. I would probably need to talk this through with @kingazm .

---

## ✅ Checklist

- [X] All 4 sections above are clearly filled out
- [ ] ~~Tests and documentation~~ updated N.A.

