### PR TITLE
feat: remove username field from registration, fix invalid credentials message

### DIFF
--- a/keycloak-theme/src/login/KcPage.tsx
+++ b/keycloak-theme/src/login/KcPage.tsx
@@ -228,17 +228,6 @@ function RegisterPage({ kcContext }: { kcContext: KcContext & { pageId: 'registe
           </div>
 
           <div className="field">
-            <label>{msgStr('username')}</label>
-            <input
-              type="text"
-              name="username"
-              defaultValue={attrs.username?.value ?? ''}
-              required
-            />
-            {fieldError('username') && <div className="field-error">{fieldError('username')}</div>}
-          </div>
-
-          <div className="field">
             <label>{msgStr('password')}</label>
             <input
               type="password"

--- a/keycloak-theme/src/login/i18n.ts
+++ b/keycloak-theme/src/login/i18n.ts
@@ -30,6 +30,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
       reqDigit: 'At least one digit',
       reqSpecial: 'At least one special character',
       reqMatch: 'Passwords match',
+      invalidUserMessage: 'Invalid email or password.',
     },
     pl: {
       loginTitle: 'Logowanie',
@@ -57,6 +58,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
       reqDigit: 'Co najmniej jedna cyfra',
       reqSpecial: 'Co najmniej jeden znak specjalny',
       reqMatch: 'Hasła są zgodne',
+      invalidUserMessage: 'Nieprawidłowy email lub hasło.',
     },
   })
   .build();


### PR DESCRIPTION
…s message

## 📄 Pull Request Description

---

### 🧩 What was changed?

Removed the username field from the Keycloak registration form. Updated the invalid credentials error message to use "email" instead of "username" in both English and Polish.

---

### 💡 Why was it changed?

The app uses email as username (registrationEmailAsUsername = true in Keycloak), so the username field was redundant and confusing for users. The error message "Invalid username or password" was also misleading since users log in with email.

---

### ⚙️ How was it implemented?

Removed the username input field from RegisterPage component in KcPage.tsx

Added custom translation override for invalidUserMessage key in i18n.ts for both EN and PL

---

### ⚠️ Side Effects or Risks

None

---

## ✅ Checklist

- [ ] All 4 sections above are clearly filled out
- [ ] Tests and documentation updated 

