### PR TITLE
feat: add theme change button

### DIFF
--- a/app/components/shared/top_bar.tsx
+++ b/app/components/shared/top_bar.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { appRoutes } from '~/lib/app_routes';
 import { useState, useEffect } from 'react';
-import { Contrast } from 'lucide-react';
+import { Contrast, Moon, Sun } from 'lucide-react';
 
 export function TopBar({ isLoginPage }: { isLoginPage: boolean }) {
   const { keycloak, initialized } = useKeycloak();
@@ -20,6 +20,13 @@ export function TopBar({ isLoginPage }: { isLoginPage: boolean }) {
     return Number(localStorage.getItem('jucaneat-contrast') ?? 1);
   });
 
+  const [isDark, setIsDark] = useState(() => {
+    const saved = localStorage.getItem('jucaneat-theme');
+    if (saved === 'dark') return true;
+    if (saved === 'light') return false;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
   useEffect(() => {
     const root = document.documentElement;
     root.style.filter = contrast > 1 ? `contrast(${contrast})` : '';
@@ -27,6 +34,11 @@ export function TopBar({ isLoginPage }: { isLoginPage: boolean }) {
     root.style.setProperty('--contrast-level', String((contrast - 1) / 0.2));
     localStorage.setItem('jucaneat-contrast', String(contrast));
   }, [contrast]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDark);
+    localStorage.setItem('jucaneat-theme', isDark ? 'dark' : 'light');
+  }, [isDark]);
 
   const handleLogin = () => {
     if (!initialized) return;
@@ -109,6 +121,15 @@ export function TopBar({ isLoginPage }: { isLoginPage: boolean }) {
                 onClick={() => switchLanguage('pl')}
               >
                 PL
+              </Button>
+              <Button
+                size="xsm"
+                variant="outline"
+                className="border-gray-200 shadow-sm bg-white text-black hover:bg-gray-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white dark:hover:bg-zinc-800"
+                aria-label={t('topBar.themeToggle')}
+                onClick={() => setIsDark(d => !d)}
+              >
+                {isDark ? <Sun size={14} /> : <Moon size={14} />}
               </Button>
               <Popover>
                 <PopoverTrigger asChild>

--- a/app/i18n.ts
+++ b/app/i18n.ts
@@ -14,6 +14,7 @@ const resources = {
         contrastReset: 'Reset',
         contrastNormal: 'Normal',
         contrastHigh: 'High',
+        themeToggle: 'Toggle theme',
       },
       common: {
         loading: 'Loading...',
@@ -287,6 +288,7 @@ const resources = {
         contrastReset: 'Resetuj',
         contrastNormal: 'Normalny',
         contrastHigh: 'Wysoki',
+        themeToggle: 'Przełącz motyw',
       },
       common: {
         loading: 'Ładowanie...',

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -57,6 +57,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `(function(){var s=localStorage.getItem('jucaneat-theme');if(s==='dark'||(s==null&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark');}})();`,
+        }}
+      />
       <body className="bg-gradient-to-b from-sky-50 via-white to-white dark:bg-gradient-to-b dark:from-zinc-800 dark:via-zinc-950 dark:to-black">
         {children}
         <ScrollRestoration />

--- a/app/tailwind_styles.css
+++ b/app/tailwind_styles.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+@variant dark (&:where(.dark, .dark *));
+
 @media (prefers-color-scheme: light) {
   html.high-contrast * {
     border-color: rgb(0 0 0 / 0.15) !important;


### PR DESCRIPTION
## 📄 Pull Request Description 
                                                
  ---                                                       
## 🧩 What was changed?
Added a light/dark theme toggle button to the top bar, placed directly to the left of the existing contrast slider button.                                                                                                                                                            
  - app/components/shared/top_bar.tsx - new toggle button + isDark state and effect
  - app/tailwind_styles.css - switched dark mode from media-query to class-based                    
  - app/root.tsx - added inline script for flash-free theme initialization      
  - app/i18n.ts - added themeToggle translation key (EN + PL)                                       
                       
  ---                                                                                               
## 💡 Why was it changed?
  Previously, dark mode was controlled entirely by the OS/browser prefers-color-scheme setting with
  no way to override it from within the app. Users who want dark mode on a light-mode system (or    
  vice versa) had no way to switch. This brings the theme control in-app, consistent with how the
  contrast and language settings already work.  In addition, this was also project's supervisor suggestion.                                                
                        
  ---
  ## ⚙️  How was it implemented?
  - isDark is initialised from localStorage('jucaneat-theme'), falling back to
  window.matchMedia('(prefers-color-scheme: dark)') so first-time visitors get the theme      
  automatically.
  - A useEffect toggles the dark class on <html> and persists the choice to localStorage
   on every change.                                                                                 
  - Flash prevention: An inline <script> in root.tsx runs synchronously before the <body> renders,
  applying the dark class from storage before React hydrates. No flash of wrong theme on hard      
  reload.              
  - Added tailwind @variant dark (&:where(.dark, .dark *)); to tailwind_styles.css to switch from  
  the default @media (prefers-color-scheme) variant to a class-based one, so the button actually    
  controls all dark: utility classes.
  - Button: Uses the same xsm size and border/bg styling as the EN/PL and contrast buttons. Shows   
  Moon icon in light mode and Sun icon in dark mode (lucide-react, already a project dependency).   

  ---             
 ## ⚠️  Side Effects or Risks
  - Behaviour change for existing users: Dark mode now requires the dark class on <html> instead of
  the OS media query. On first load, the inline script mirrors the system preference, so existing   
  users will see no change, but if localStorage ever has a stale value it will override the system
  setting.                                                                                          
  - Classes in the app now respond to the class rather than the media query. Any component
   that relied on automatic OS-driven dark mode will now only switch when the user explicitly       
  toggles or when the inline script fires on load. This is intentional but is a global behaviour
  change.                                                                                           
                                                                                                    
  ---
  ## ✅ Checklist                                                                                      
                  
  - [X] All 4 sections above are clearly filled out
  - [ ] Tests and documentation updated N/A, tested manually